### PR TITLE
Make socketURL an environment var

### DIFF
--- a/public/js/config.js
+++ b/public/js/config.js
@@ -92,6 +92,6 @@ var getRandomConfig = function(){
     return [selectIdx, leaderMovementIndexes, roomVictimMapping, victimIndexes]
 }
 
-var socketURL = "https://asist-api.herokuapp.com/"
+var socketURL = process.env.SOCKET_URL
 
 export {phaserConfig, getMapData, getGameData, socketURL, getRandomConfig};


### PR DESCRIPTION
Enable socketURL to be set as an environment var by a cloud platform,
such as Heroku. This would prevent unnecessary merge conflicts once we start working on the Client in the forked repo model. Each dev has their own app